### PR TITLE
Changed state of XSMU_NANOVOLTMETER to OFF

### DIFF
--- a/lab_database.yaml
+++ b/lab_database.yaml
@@ -587,7 +587,7 @@ Lab_Space:
               
           XSMU_NANOVOLTMETER:
 
-              State                           : NOT_IN_LABSPACE
+              State                           : OFF
               Power_Cable                     : DISCONNECTED
               USB_Cable_Computer              : DISCONNECTED
               USB_Cable_Module                : DISCONNECTED


### PR DESCRIPTION
The input of the ADC has been shorted to ground, bypassing the amplifier in the signal chain before it.